### PR TITLE
Remove /docu-dev/ from links

### DIFF
--- a/docs/build/quickstart.mdx
+++ b/docs/build/quickstart.mdx
@@ -30,7 +30,7 @@ We recommend using Node.js version 18 or later, and the compatible npm version. 
 You'll need a funded Massa wallet and your secret key before you deploy your smart contract to the Massa blockchain. 
 
 :::info
-Not sure how to create and fund a Massa wallet? Check our guide [here](/docu-dev/docs/build/wallet/intro).
+Not sure how to create and fund a Massa wallet? Check our guide [here](/docs/build/wallet/intro).
 :::
 
 ### Setting up Your Project
@@ -48,7 +48,7 @@ npx @massalabs/sc-project-initializer init massa-hello-world
 With this command, you create a new folder named massa-hello-world with all the necessary files for developing a Massa smart contract.
 
 :::info
-For more comprehensive details on the layout of the smart contract project, please refer to our guide [here](/docu-dev/docs/build/smart-contract/project-layout).
+For more comprehensive details on the layout of the smart contract project, please refer to our guide [here](/docs/build/smart-contract/project-layout).
 
 In the meantime, here are the key components you should be familiar with:
 

--- a/docs/learn/architecture/basic-concepts.mdx
+++ b/docs/learn/architecture/basic-concepts.mdx
@@ -242,7 +242,7 @@ Transactions are operations that move native Massa coins between addresses. Here
 #### Buy/Sell Rolls operations
 
 Rolls are staking tokens that participants can buy or sell with native Massa coins. By owning rolls, 
-addresses can participate in block creation  [more about staking below](/docu-dev/docs/node/stake). 
+addresses can participate in block creation  [more about staking below](/docs/node/stake). 
 This is done via special operations, with a simple payload:
 
 <table>
@@ -402,6 +402,6 @@ The content of a block is as follows:
 Endorsements are optional inclusion in the block, but their inclusion is incentivized for block creators. They are 
 validations of the fact that the parent block on the thread of the block is the best parent that could have been 
 chosen, done by other nodes that have also been deterministically selected via the proof of stake probability 
-distribution (see below). A comprehensive description of endorsements can be found [here](/docu-dev/docs/learn/architecture/consensus-quality#endorsement), so we will 
+distribution (see below). A comprehensive description of endorsements can be found [here](/docs/learn/architecture/consensus-quality#endorsement), so we will 
 not go further into details in the context of this introduction.
 

--- a/docs/learn/architecture/node-architecture.mdx
+++ b/docs/learn/architecture/node-architecture.mdx
@@ -35,7 +35,7 @@ network so you have to be careful on which node you connect to avoid downloading
 ## API Module
 
 The API Module is the public window of the node to the rest of the world. It allows for interactions with external clients or
-factories via a [JSON RPC](/docu-dev/docs/build/api/jsonrpc) and [gRPC](/docu-dev/docs/build/api/grpc) protocols.
+factories via a [JSON RPC](/docs/build/api/jsonrpc) and [gRPC](/docs/build/api/grpc) protocols.
 
 The API includes interfaces to do the following:
 
@@ -77,7 +77,7 @@ The probabilistic “surface” of a participant is equal to its total stake, wh
 because the stake would have to be split between them anyway.
 
 :::note
-More about slashing mechanism [here](/docu-dev/docs/learn/architecture/consensus-quality#slashing)
+More about slashing mechanism [here](/docs/learn/architecture/consensus-quality#slashing)
 :::
 
 The method used to draw an elected node for a given slot is simply a random draw from a distribution where addresses are


### PR DESCRIPTION
Needed for deployment to docs.massa.net